### PR TITLE
Fix DataFrameProxy race in _monitor_df_changes (fixes #16)

### DIFF
--- a/src/enamlext/qt/qt_dataframe.py
+++ b/src/enamlext/qt/qt_dataframe.py
@@ -14,7 +14,7 @@ def _monitor_df_changes(df_proxy):
     if df_proxy.instrumentation_enabled:
         logger.info('Starting DataFrameProxy thread for monitoring changes and refreshing ticking cells '
                     f'{threading.current_thread()}')
-    
+
     from enaml.application import deferred_call
 
     current_values = df_proxy.values
@@ -26,7 +26,13 @@ def _monitor_df_changes(df_proxy):
         if df_proxy.instrumentation_enabled:
             t0 = time.perf_counter()
 
-        new_values = df_proxy.df.values.copy()
+        # Snapshot under the lock — on object-dtype frames, building `.values`
+        # iterates pandas blocks and copies PyObject* pointers; if the caller
+        # mutates the same frame from another thread mid-read, we can deref a
+        # freed pointer and segfault. Diff/notify happens outside the lock so
+        # callers aren't blocked on the comparison work.
+        with df_proxy._lock:
+            new_values = df_proxy.df.values.copy()
 
         row_indexes, col_indexes = np.where(~((current_values == new_values) | (pd.isna(current_values) & pd.isna(new_values))))
 
@@ -56,6 +62,7 @@ class DataFrameProxy:
         if tick_interval_ms <= 0 and refresh_cells_callback is not None:
             raise ValueError('You should specify a tick_interval_ms refresh interval in miliseconds when you '
                              'pass a refresh_cells_callback.')
+        self._lock = threading.RLock()
         self.values = df.values
         self.df = df
         self.tick_interval_ms = tick_interval_ms
@@ -63,11 +70,24 @@ class DataFrameProxy:
         self.instrumentation_enabled = instrumentation_enabled
         self._is_active = True
         if self.is_ticking:
-            import threading
             t = threading.Thread(target=_monitor_df_changes,
                                  args=(self,),
                                  daemon=True)
             t.start()
+
+    def write(self, fn: Callable[[pd.DataFrame], None]) -> None:
+        """Run ``fn(self.df)`` under the proxy's lock.
+
+        Use this to coordinate in-place mutations of the wrapped DataFrame
+        with the background change-monitor on ticking proxies::
+
+            proxy.write(lambda df: df.update(other_df[ticking_columns]))
+
+        On non-ticking proxies the lock is uncontended so this is a cheap
+        no-op around ``fn`` and callers can use it unconditionally.
+        """
+        with self._lock:
+            fn(self.df)
 
     def update_values_and_refresh_cells(self, new_values, row_indexes, col_indexes):
         # must be called in the main thread!

--- a/tests/qt/test_qt_dataframe.py
+++ b/tests/qt/test_qt_dataframe.py
@@ -1,0 +1,66 @@
+import threading
+
+import pandas as pd
+
+from enamlext.qt.qt_dataframe import DataFrameProxy
+
+
+def test_proxy_has_lock():
+    proxy = DataFrameProxy(pd.DataFrame({'a': [1, 2, 3]}))
+    assert isinstance(proxy._lock, type(threading.RLock()))
+
+
+def test_write_runs_callable_under_lock_and_passes_df():
+    df = pd.DataFrame({'a': [1, 2, 3]})
+    proxy = DataFrameProxy(df)
+
+    seen = []
+
+    def mutate(d):
+        seen.append(d)
+        d['a'] = [10, 20, 30]
+
+    proxy.write(mutate)
+
+    assert seen == [df]
+    assert proxy.df is df
+    assert proxy.df['a'].tolist() == [10, 20, 30]
+
+
+def test_write_lock_is_reentrant():
+    # RLock so callers can nest writes (e.g. helper that calls another helper)
+    proxy = DataFrameProxy(pd.DataFrame({'a': [1]}))
+
+    def outer(d):
+        proxy.write(lambda inner: inner.__setitem__('a', [99]))
+
+    proxy.write(outer)
+    assert proxy.df['a'].tolist() == [99]
+
+
+def test_write_serializes_concurrent_mutations():
+    # Two threads hammering write() must not interleave inside fn
+    proxy = DataFrameProxy(pd.DataFrame({'a': [0]}))
+    inside = 0
+    max_inside = 0
+    inside_lock = threading.Lock()
+
+    def fn(_d):
+        nonlocal inside, max_inside
+        with inside_lock:
+            inside += 1
+            max_inside = max(max_inside, inside)
+        # do a touch of work so the race window is real
+        for _ in range(1000):
+            pass
+        with inside_lock:
+            inside -= 1
+
+    threads = [threading.Thread(target=lambda: [proxy.write(fn) for _ in range(50)])
+               for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert max_inside == 1


### PR DESCRIPTION
## Summary

- Adds a `threading.RLock` to `DataFrameProxy` and snapshots `df.values` under it in the background `_monitor_df_changes` thread, fixing the segfault on object-dtype frames described in #16.
- Adds `DataFrameProxy.write(fn)` so callers can wrap in-place mutations (`proxy.write(lambda df: df.update(other_df[cols]))`) and coordinate with the monitor — the natural counterpart to the implicit "mutate in place, I'll detect changes" contract that ticking proxies offer.
- Diff/notify happens outside the lock so callers aren't blocked on the comparison.

## Why

`df_proxy.df.values` on a mixed-dtype DataFrame returns an object ndarray; building it iterates each pandas block and copies `PyObject*` pointers. If the caller is mid-`update()` on another thread (pandas reassigns the underlying numpy buffer of the affected block), the monitor reads pointers from a buffer that's being freed/reused. The next `==` or `pd.isna` touches a freed pointer, INCREF blows up, segfault. See #16 for the full traceback / analysis.

Pure-numeric frames are not exposed — numpy float blocks don't manage Python references — but any frame with even one object column is.

## Test plan

- [x] New tests in `tests/qt/test_qt_dataframe.py`:
  - lock exists on the proxy
  - `write()` runs the callable under the lock and passes through the wrapped df
  - lock is reentrant (so nested helpers can call `write`)
  - concurrent `write()` calls from multiple threads are serialized (no interleaving inside `fn`)
- [x] Full existing test suite passes (19/19, including `test_column.py` which constructs `DataFrameProxy` instances).

## Migration notes

- Callers who only ever replace the reference (`proxy.df = new_df`) need no change — Python attribute writes are atomic at the bytecode level, and the monitor's `with self._lock: snapshot = df_proxy.df.values.copy()` will snapshot whichever frame `proxy.df` happened to point to at lock acquisition.
- Callers using the in-place soft-update path migrate from `proxy.df.update(cols)` to `proxy.write(lambda df: df.update(cols))`. On non-ticking proxies the lock is uncontended so `write()` is a cheap no-op around `fn` and can be used unconditionally.

Closes #16.