### PR TITLE
fix: use pd.api.types.is_numeric_dtype for column type detection

### DIFF
--- a/src/enamlext/qt/table/column.py
+++ b/src/enamlext/qt/table/column.py
@@ -191,7 +191,10 @@ def generate_columns(items: Sequence, *, hints: Optional[Dict] = None,
                 continue
             if include is not None and name not in include_set:
                 continue
-            if not isinstance(dtype, pd.core.dtypes.dtypes.CategoricalDtype) and np.issubdtype(dtype, np.number):
+            # pd.api.types.is_numeric_dtype handles pandas extension dtypes (StringDtype,
+            # CategoricalDtype, Int64Dtype, ...) that np.issubdtype cannot interpret as
+            # data types and would raise TypeError on.
+            if pd.api.types.is_numeric_dtype(dtype):
                 align = Alignment.RIGHT
                 style = get_cell_style_for_negative_numbers
             else:


### PR DESCRIPTION
np.issubdtype(dtype, np.number) raises TypeError on pandas extension dtypes such as StringDtype (which became the default string storage under pd.options.future.infer_string in recent pandas versions). pd.api.types.is_numeric_dtype is pandas-aware and correctly returns False for non-numeric extension dtypes like StringDtype and CategoricalDtype, while still returning True for numeric extension dtypes such as Int64Dtype. This subsumes the previous CategoricalDtype special-case.